### PR TITLE
Fix detection of top-level environment

### DIFF
--- a/session-01/task-02/word_index.py
+++ b/session-01/task-02/word_index.py
@@ -14,5 +14,5 @@ def main():
     raise NotImplementedError()
 
 
-if __name__ == 'main':
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
According to [the docs](https://docs.python.org/3.7/library/__main__.html) the top-level environment can be detected by checking the global `__name__` variable against `__main__`, not `main`.